### PR TITLE
Fix loading error

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $ pip install git+https://github.com/hyperledger/aries-acapy-plugin-toolbox.git@
 
 Start up ACA-Py with the plugin parameter:
 ```sh
-$ aca-py start -it localhost 3000 -ot http -e http://localhost 3000 --plugin acapy_plugin_toolbox
+$ aca-py start -it localhost 3000 -ot http -e http://localhost:3000 --plugin acapy_plugin_toolbox
 ```
 
 To use all the features of the toolbox, you'll need the `indy` feature installed

--- a/acapy_plugin_toolbox/__init__.py
+++ b/acapy_plugin_toolbox/__init__.py
@@ -1,7 +1,7 @@
 """Plugin setup."""
 
 from aries_cloudagent.config.injection_context import InjectionContext
-from aries_cloudagent.messaging.protocol_registry import ProtocolRegistry
+from aries_cloudagent.core.protocol_registry import ProtocolRegistry
 
 from .connections import MESSAGE_TYPES as CONNECTION_MESSAGES
 from .credential_definitions import MESSAGE_TYPES as CRED_DEF_MESSAGES


### PR DESCRIPTION
Due to the changes in mater branch of aca-py plugin is not able to load protocol_registry anymore. See commit message for details.