### PR TITLE
Rename admin_basicmessage -> admin-basicmessage

### DIFF
--- a/acapy_plugin_toolbox/basicmessage.py
+++ b/acapy_plugin_toolbox/basicmessage.py
@@ -33,7 +33,7 @@ PROTOCOL_URI = "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/basicmessage/1.0"
 BASIC_MESSAGE = f"{PROTOCOL_URI}/message"
 
 ADMIN_PROTOCOL_URI = "https://github.com/hyperledger/" \
-    "aries-toolbox/tree/master/docs/admin_basicmessage/0.1"
+    "aries-toolbox/tree/master/docs/admin-basicmessage/0.1"
 GET = f"{ADMIN_PROTOCOL_URI}/get"
 SEND = f"{ADMIN_PROTOCOL_URI}/send"
 DELETE = f"{ADMIN_PROTOCOL_URI}/delete"


### PR DESCRIPTION
For consistency across admin protocol names.

Should be merged with https://github.com/hyperledger/aries-toolbox/pull/139