### PR TITLE
Fixes for basic message handler

### DIFF
--- a/acapy_plugin_toolbox/basicmessage.py
+++ b/acapy_plugin_toolbox/basicmessage.py
@@ -236,9 +236,11 @@ class BasicMessageHandler(BaseHandler):
         admins = await ConnectionRecord.query(
             context, post_filter={'their_role': 'admin'}
         )
+
         if not admins:
             return
 
+        admins = filter(lambda admin: admin.state == 'active', admins)
         admin_verkeys = [
             target.recipient_keys[0]
             for admin in admins
@@ -246,6 +248,7 @@ class BasicMessageHandler(BaseHandler):
                 connection=admin
             )
         ]
+
         notification = New(
             connection_id=context.connection_record.connection_id,
             message=msg

--- a/acapy_plugin_toolbox/basicmessage.py
+++ b/acapy_plugin_toolbox/basicmessage.py
@@ -221,10 +221,24 @@ class BasicMessageHandler(BaseHandler):
             state=BasicMessageRecord.STATE_RECV
         )
         await msg.save(context, reason='New message received.')
+
+        await responder.send_webhook(
+            "basicmessages",
+            {
+                "connection_id": context.connection_record.connection_id,
+                "message_id": context.message._id,
+                "content": context.message.content,
+                "state": "received",
+            },
+        )
+
         connection_mgr = ConnectionManager(context)
         admins = await ConnectionRecord.query(
             context, post_filter={'their_role': 'admin'}
         )
+        if not admins:
+            return
+
         admin_verkeys = [
             target.recipient_keys[0]
             for admin in admins


### PR DESCRIPTION
This will cause basicmessage topics to be sent to webhooks if available.

Also fixes an error that occurs when invitations are attempted to be used as a potential connection target for sending a notification.