### PR TITLE
update von-image to 1.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bcgovimages/von-image:py36-1.14-0
+FROM bcgovimages/von-image:py36-1.15-0
 
 USER root
 RUN apt-get update


### PR DESCRIPTION
Small PR that updates the bcgov von-image to 1.15. 

This resolves the IndyError that was thrown a lot when using 1.14:

```
agent-bob_1    | 2020-10-07 19:12:32,902 indy.libindy.native.indy.services.pool.pool ERROR 	src/services/pool/pool.rs:701 | Error during retrieving nodes: IndyError { inner:
agent-bob_1    |
agent-bob_1    | Node is not a validator
agent-bob_1    |
agent-bob_1    | Invalid library state }
```