### PR TITLE
chore: replaced reference to "master" with "main"

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ $ pip install -e .[indy]
 Install this plugin into the virtual environment:
 
 ```sh
-$ pip install git+https://github.com/hyperledger/aries-acapy-plugin-toolbox.git@master#egg=acapy_plugin_toolbox
+$ pip install git+https://github.com/hyperledger/aries-acapy-plugin-toolbox.git@main#egg=acapy_plugin_toolbox
 ```
 
 **Note:** Depending on your version of `pip`, you may need to drop the


### PR DESCRIPTION
While going through the readme to setup a development environment, the
plugin failed to install due to the `pip install` command pointing to
the wrong branch. This change fixes that reference.

Signed-off-by: Colton Wolkins (Laptop) <colton@indicio.tech>