### PR TITLE
Add presentation request to the "get-matching-credentials" call

### DIFF
--- a/acapy_plugin_toolbox/holder/v0_1/messages/pres_get_matching_credentials.py
+++ b/acapy_plugin_toolbox/holder/v0_1/messages/pres_get_matching_credentials.py
@@ -62,6 +62,7 @@ class PresGetMatchingCredentials(AdminHolderMessage):
                 self.paginate.limit,
                 extra_query={},
             ),
+            presentation_request=pres_ex_record.presentation_request,
             page=Page(count_=self.paginate.limit, offset=self.paginate.offset),
         )
         matches.assign_thread_from(self)

--- a/acapy_plugin_toolbox/holder/v0_1/messages/pres_matching_credentials.py
+++ b/acapy_plugin_toolbox/holder/v0_1/messages/pres_matching_credentials.py
@@ -6,6 +6,9 @@ from marshmallow import fields
 from ....decorators.pagination import Page
 from ....util import expand_message_class, with_generic_init
 from .base import AdminHolderMessage
+from aries_cloudagent.protocols.present_proof.v1_0.models.presentation_exchange import (
+    V10PresentationExchange as PresExRecord,
+)
 
 
 @with_generic_init
@@ -21,6 +24,10 @@ class PresMatchingCredentials(AdminHolderMessage):
         presentation_exchange_id = fields.Str(
             required=True, description="Exchange ID for matched credentials."
         )
+        # TODO Use a toolbox PresentationExchangeRepresentation
+        presentation_request = fields.Mapping(
+            required=True, description="Presentation Request associated with the Presentation Exchange ID."
+        )
         matching_credentials = fields.Nested(
             IndyCredPrecisSchema, many=True, description="Matched credentials."
         )
@@ -33,6 +40,7 @@ class PresMatchingCredentials(AdminHolderMessage):
     def __init__(
         self,
         presentation_exchange_id: str,
+        presentation_request: PresExRecord,
         matching_credentials: Tuple[Any, ...],
         page: Page = None,
         **kwargs,
@@ -40,5 +48,6 @@ class PresMatchingCredentials(AdminHolderMessage):
         """Initialize PresMatchingCredentials"""
         super().__init__(**kwargs)
         self.presentation_exchange_id = presentation_exchange_id
+        self.presentation_request = presentation_request
         self.matching_credentials = matching_credentials
         self.page = page

--- a/acapy_plugin_toolbox/holder/v0_1/messages/pres_matching_credentials.py
+++ b/acapy_plugin_toolbox/holder/v0_1/messages/pres_matching_credentials.py
@@ -26,7 +26,8 @@ class PresMatchingCredentials(AdminHolderMessage):
         )
         # TODO Use a toolbox PresentationExchangeRepresentation
         presentation_request = fields.Mapping(
-            required=True, description="Presentation Request associated with the Presentation Exchange ID."
+            required=True,
+            description="Presentation Request associated with the Presentation Exchange ID.",
         )
         matching_credentials = fields.Nested(
             IndyCredPrecisSchema, many=True, description="Matched credentials."


### PR DESCRIPTION
When requesting matching credentials to a presentation, the credentials are returned without any indication of what the verifier requested. This change adds the presentation request to the response which will reduce API requests and unneeded complexity for the prover.