### PR TITLE
fix: Switch from Sovrin StagingNet to BuilderNet

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ To use all the features of the toolbox, you'll need the `indy` feature installed
 (as described in [Setup Aries Cloud Agent -
 Python](#setup-aries-cloud-agent-python)). [Check out the demo configurations
 for Alice or Bob](demo/configs/alice.yml) for a configuration using the Sovrin
-StagingNet and some reasonable defaults.
+BuilderNet and some reasonable defaults.
 
 ### Combined HTTP+WS Transport
 This plugin includes a side-loadable combined HTTP and WebSocket transport

--- a/demo/README.md
+++ b/demo/README.md
@@ -8,7 +8,7 @@ This folder contains setups for multiple scenarios:
 - And a mediator networked with ngrok that can be mixed in with the single agent
   or Alice and Bob scenarios for demonstrating mediation.
 
-Where applicable, agents are connected to the Sovrin StagingNet to enable
+Where applicable, agents are connected to the Sovrin BuilderNet to enable
 credentials exchange. You can anchor your DID and become an endorser (able to
 write schemas and credential definitions) at https://selfserve.sovrin.org.
 

--- a/demo/configs/alice.yml
+++ b/demo/configs/alice.yml
@@ -16,8 +16,8 @@ plugin:
 outbound-transport: http
 
 # Ledger
-# Use Sovrin Staging Net. Become an endorser at https://selfserve.sovrin.org.
-genesis-url: https://raw.githubusercontent.com/sovrin-foundation/sovrin/master/sovrin/pool_transactions_sandbox_genesis
+# Use Sovrin Builder Net. Become an endorser at https://selfserve.sovrin.org.
+genesis-url: https://raw.githubusercontent.com/sovrin-foundation/sovrin/master/sovrin/pool_transactions_builder_genesis
 
 # Admin
 admin-insecure-mode: true

--- a/demo/configs/bob.yml
+++ b/demo/configs/bob.yml
@@ -16,8 +16,8 @@ plugin:
 outbound-transport: http
 
 # Ledger
-# Use Sovrin Staging Net. Become an endorser at https://selfserve.sovrin.org.
-genesis-url: https://raw.githubusercontent.com/sovrin-foundation/sovrin/master/sovrin/pool_transactions_sandbox_genesis
+# Use Sovrin Builder Net. Become an endorser at https://selfserve.sovrin.org.
+genesis-url: https://raw.githubusercontent.com/sovrin-foundation/sovrin/master/sovrin/pool_transactions_builder_genesis
 
 # Admin
 admin-insecure-mode: true

--- a/demo/configs/common.yml
+++ b/demo/configs/common.yml
@@ -6,8 +6,8 @@ plugin:
 outbound-transport: http
 
 # Ledger
-# Use Sovrin Staging Net. Become an endorser at https://selfserve.sovrin.org.
-genesis-url: https://raw.githubusercontent.com/sovrin-foundation/sovrin/master/sovrin/pool_transactions_sandbox_genesis
+# Use Sovrin Builder Net. Become an endorser at https://selfserve.sovrin.org.
+genesis-url: https://raw.githubusercontent.com/sovrin-foundation/sovrin/master/sovrin/pool_transactions_builder_genesis
 
 # Admin
 admin-insecure-mode: true

--- a/demo/configs/default.yml
+++ b/demo/configs/default.yml
@@ -17,8 +17,8 @@ endpoint:
   - ws://localhost:3000
 
 # Ledger
-# Use Sovrin Staging Net. Become an endorser at https://selfserve.sovrin.org.
-genesis-url: https://raw.githubusercontent.com/sovrin-foundation/sovrin/master/sovrin/pool_transactions_sandbox_genesis
+# Use Sovrin Builder Net. Become an endorser at https://selfserve.sovrin.org.
+genesis-url: https://raw.githubusercontent.com/sovrin-foundation/sovrin/master/sovrin/pool_transactions_builder_genesis
 
 # Connections
 debug-connections: true


### PR DESCRIPTION
Due to a recent change, the StagingNet is no longer free. It is
recommended that developers switch to the BuilderNet for development
purposes. If an application reaches a state where it is applicable for a
prototype or pre-production uses, the StagingNet should be used instead.

Please see https://selfserve.sovrin.org/ for more information about the
different Sovrin networks.

This commit changes all references to the StagingNet to point to the
BuilderNet instead.

Signed-off-by: Colton Wolkins (Indicio work address) <colton@indicio.tech>