### PR TITLE
chore: Update readme with tip to install the Indy SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ $ pip install -e .
 ```sh
 $ pip install -e .[indy]
 ```
+Note: If you are using the `indy` feature, you will need to have the indy-sdk
+library installed. If it's not installed, please see
+[Installing the SDK](https://github.com/hyperledger/indy-sdk/blob/master/README.md#installing-the-sdk)
 
 ### Plugin Installation
 


### PR DESCRIPTION
When following the instructions to setup the the Aries Cloud Agent -
Python, there is a section informing the user that they may run a pip
install of ACA-PY with indy support. These instructions do not indicate
whether or not the indy-SDK is needed, nor does it inform the user how
they should install it. I have added that critical documentation.

Signed-off-by: Colton Wolkins (Indicio work address) <colton@indicio.tech>