### PR TITLE
fix: acapy-endpoint.sh to send correct ws endpoint to ACA-Py

### DIFF
--- a/demo/acapy-endpoint.sh
+++ b/demo/acapy-endpoint.sh
@@ -9,6 +9,6 @@ done
 ACAPY_ENDPOINT=$(curl --silent "${TUNNEL_ENDPOINT}/start" | python -c "import sys, json; print(json.load(sys.stdin)['url'])")
 echo "fetched end point [$ACAPY_ENDPOINT]"
 
-export ACAPY_ENDPOINT="[$ACAPY_ENDPOINT, ${ACAPY_ENDPOINT/http/ws}/ws]"
+export ACAPY_ENDPOINT="[$ACAPY_ENDPOINT, ${ACAPY_ENDPOINT/http/ws}]"
 #export ACAPY_ENDPOINT="$ACAPY_ENDPOINT"
 exec "$@"


### PR DESCRIPTION
It was noticed that the Toolbox was "unable to connect" to the demos due
to the fact that the websocket endpoint was not set properly. When the
toolbox would attempt to discover the features of the ACA-Py instance,
it was sending the request to ws://host/ws (which isn't a valid
endpoint) instead of sending it to ws://host/.

Signed-off-by: Colton Wolkins (Indicio work address) <colton@indicio.tech>