### PR TITLE
Fix/mediator demo

### DIFF
--- a/demo/configs/mediator.yml
+++ b/demo/configs/mediator.yml
@@ -30,3 +30,6 @@ auto-ping-connection: true
 # Mediation
 open-mediation: true
 enable-undelivered-queue: true
+wallet-type: indy
+wallet-key: "insecure, for use in demo only"
+auto-provision: true


### PR DESCRIPTION
The mediator had some intermittent issues connecting to the toolbox, due to the in-memory wallet used when no wallet is specified. Specifying a wallet bypasses these issues. 