### PR TITLE
feat: replace connections with oob for invites in all demo configs

### DIFF
--- a/demo/configs/alice.yml
+++ b/demo/configs/alice.yml
@@ -29,7 +29,7 @@ debug-presentations: true
 auto-accept-invites: true
 auto-accept-requests: true
 auto-ping-connection: true
-connections-invite: true
+invite: true
 invite-metadata-json: '{"group": "admin"}'
 
 # Credentials and Presentations

--- a/demo/configs/bob.yml
+++ b/demo/configs/bob.yml
@@ -29,7 +29,7 @@ debug-presentations: true
 auto-accept-invites: true
 auto-accept-requests: true
 auto-ping-connection: true
-connections-invite: true
+invite: true
 invite-metadata-json: '{"group": "admin"}'
 
 # Credentials and Presentations

--- a/demo/configs/common.yml
+++ b/demo/configs/common.yml
@@ -18,7 +18,7 @@ debug-credentials: true
 debug-presentations: true
 auto-accept-invites: true
 auto-accept-requests: true
-connections-invite: true
+invite: true
 invite-metadata-json: '{"group": "admin"}'
 
 # Credentials and Presentations

--- a/demo/configs/default.yml
+++ b/demo/configs/default.yml
@@ -29,7 +29,7 @@ auto-accept-requests: true
 auto-ping-connection: true
 
 # Generate Admin Invitation
-connections-invite: true
+invite: true
 invite-label: ACA-Py (Admin)
 invite-metadata-json: '{"group": "admin"}'
 

--- a/demo/configs/mediator.yml
+++ b/demo/configs/mediator.yml
@@ -21,7 +21,7 @@ admin-insecure-mode: true
 
 # Connections
 debug-connections: true
-connections-invite: true
+invite: true
 invite-multi-use: true
 auto-accept-invites: true
 auto-accept-requests: true
@@ -30,6 +30,3 @@ auto-ping-connection: true
 # Mediation
 open-mediation: true
 enable-undelivered-queue: true
-wallet-type: indy
-wallet-key: "insecure, for use in demo only"
-auto-provision: true

--- a/docker/default.yml
+++ b/docker/default.yml
@@ -13,7 +13,7 @@ debug-connections: true
 auto-accept-invites: true
 auto-accept-requests: true
 auto-ping-connection: true
-connections-invite: true
+invite: true
 label: Aries Cloud Agent + Toolbox Plugin
 invite-label: ACA-Py (Admin)
 invite-metadata-json: '{"group": "admin"}'


### PR DESCRIPTION
I may have been a smidge trigger-happy, but I replaced every instance of `connections-invite` with just `invite` in the demo configs so that they would use OOB invitations rather than Connections invitations.
Signed-off-by: Micah Peltier <micah6_8@yahoo.com>