### PR TITLE
fix: change indicio testnet genesis url to main from master

### DIFF
--- a/demo/configs/alice.yml
+++ b/demo/configs/alice.yml
@@ -17,7 +17,7 @@ outbound-transport: http
 
 # Ledger
 # Use Indicio TestNet. Become an endorser at https://selfserve.indiciotech.io/.
-genesis-url: https://raw.githubusercontent.com/Indicio-tech/indicio-network/master/genesis_files/pool_transactions_testnet_genesis
+genesis-url: https://raw.githubusercontent.com/Indicio-tech/indicio-network/main/genesis_files/pool_transactions_testnet_genesis
 
 # Admin
 admin-insecure-mode: true

--- a/demo/configs/bob.yml
+++ b/demo/configs/bob.yml
@@ -17,7 +17,7 @@ outbound-transport: http
 
 # Ledger
 # Use Indicio TestNet. Become an endorser at https://selfserve.indiciotech.io/.
-genesis-url: https://raw.githubusercontent.com/Indicio-tech/indicio-network/master/genesis_files/pool_transactions_testnet_genesis
+genesis-url: https://raw.githubusercontent.com/Indicio-tech/indicio-network/main/genesis_files/pool_transactions_testnet_genesis
 
 # Admin
 admin-insecure-mode: true


### PR DESCRIPTION
Prior to this change, running the demo with Alice and Bob resulted in an Indy error: CommonInvalidState for both Alice and Bob that caused both agents to exit. This change updates the Indicio testnet url to use "main" instead of "master," which makes this demo up-to-date with naming conventions and thus resolves the Indy error. #149 